### PR TITLE
Add Team without M365 group option to the provisioning engine

### DIFF
--- a/provisioning-engine/config/provisioning-config-schema.json
+++ b/provisioning-engine/config/provisioning-config-schema.json
@@ -145,6 +145,9 @@
         "teamSiteProvisioning": {
           "$ref": "#/definitions/entityPlugin"
         },
+        "teamSiteWithoutM365GroupProvisioning": {
+          "$ref": "#/definitions/entityPlugin"
+        },
         "msTeamsProvisioning": {
           "description": "Defines a plug-in to apply unique scripts for the MS Teams entity type",
           "type": "object",

--- a/provisioning-engine/config/sample-batch.csv
+++ b/provisioning-engine/config/sample-batch.csv
@@ -1,5 +1,5 @@
 PlaceID,Site,Title,Description,EntityType,SiteType,IsHub,AssociateToHub,Visibility
-# Valid EntityTypes used when Creating Sites = CommunicationSite;TeamSite;MSTeam;IntranetSpokeSite,,,,,
+# Valid EntityTypes used when Creating Sites = CommunicationSite;TeamSite;TeamSiteWithoutM365Group;MSTeam;IntranetSpokeSite,,,,,
 # IsHub & AssociateToHub are only used by the create / associate hubs script,,,,,
 # MSTeam Type Notes
 #     When creating an MSTeam use Site for SharePoint Url to validate but Title for the Team Name.  
@@ -7,5 +7,6 @@ PlaceID,Site,Title,Description,EntityType,SiteType,IsHub,AssociateToHub,Visibili
 #     Visibility is only used for MSTeam
 9999,test-spoke-1,"Test Spoke 1",,IntranetSpokeSite,,FALSE,,
 9999,test-team-1,"Test Team 1",,TeamSite,,FALSE,,
+9999,test-team-no-group-1,"Test Team No Group 1",,TeamSiteWithoutM365Group,,FALSE,,
 9999,test-comm-1,"Test Comm 1","Some Description",CommunicationSite,,FALSE,,
 

--- a/provisioning-engine/provision-site.ps1
+++ b/provisioning-engine/provision-site.ps1
@@ -28,7 +28,7 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$SiteTitle,
     [Parameter(Mandatory = $true)]
-    [ValidateSet("IntranetSpokeSite", "CommunicationSite", "TeamSite", "MSTeam")]    
+    [ValidateSet("IntranetSpokeSite", "CommunicationSite", "TeamSite", "TeamSiteWithoutM365Group", "MSTeam")]    
     [string]$EntityType,
     [switch]$SkipGetCredentials,
     [switch]$BatchMode
@@ -97,6 +97,7 @@ $entityTypeConfigKey = switch ($EntityType)
 {
     "CommunicationSite" { "communicationSiteProvisioning" }
     "TeamSite" { "teamSiteProvisioning" }
+    "TeamSiteWithoutM365Group" { "teamSiteWithoutM365GroupProvisioning" }
     "IntranetSpokeSite" { "intranetSpokeSiteProvisioning" }
     Default { "msTeamsProvisioning" }
 }


### PR DESCRIPTION
This PR extends the provisioning engine to separate the option of creating a team site and a team site without an M365 group.  