### PR TITLE
Change post provision task to array

### DIFF
--- a/provisioning-engine/config/provisioning-config-schema.json
+++ b/provisioning-engine/config/provisioning-config-schema.json
@@ -82,7 +82,10 @@
         },
         "postProvisioningTask": {
           "description": "A path to a PowerShell script with post-provisioning tasks",
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "provisioningScript": {
           "description": "A path to a PowerShell script to create the site and provide site provisioning",

--- a/provisioning-engine/provision-site.ps1
+++ b/provisioning-engine/provision-site.ps1
@@ -164,19 +164,22 @@ else
     }
 
     #Post-Provisioning
-    $postProvisioningScript = Get-NestedMember $config "plugins.$entityTypeConfigKey.postProvisioningTask"
-    if ($null -ne $postProvisioningScript)
+    $postProvisioningScripts = Get-NestedMember $config "plugins.$entityTypeConfigKey.postProvisioningTask"
+    if ($null -ne $postProvisioningScripts)
     {
-        if (Test-Path -Path $postProvisioningScript)
+        foreach ($postProvisioningScript in $postProvisioningScripts)
         {
-            Write-Host "Running post-provisioning script '$postProvisioningScript'"
+            if (Test-Path -Path $postProvisioningScript)
+            {
+                Write-Host "Running post-provisioning script '$postProvisioningScript'"
 
-            # Run the post-provisioning script, if there is one
-            . $postProvisioningScript -TenantUrl $config.rootSiteUrl -SitePath $Site -SiteTitle $SiteTitle -FullSiteUrl $siteUrl -ConfigFile $ConfigFile
-        }
-        else
-        {
-            Write-Warning "Could not find post-provisioning script '$postProvisioningScript'"
+                # Run the post-provisioning script, if there is one
+                . $postProvisioningScript -TenantUrl $config.rootSiteUrl -SitePath $Site -SiteTitle $SiteTitle -FullSiteUrl $siteUrl -ConfigFile $ConfigFile
+            }
+            else
+            {
+                Write-Warning "Could not find post-provisioning script '$postProvisioningScript'"
+            }
         }
     }
 


### PR DESCRIPTION
This PR changes the post provisioning task in the configuration file to accept an array of ps1 files.  This change allows for defining common post-provisioning plugins that can be shared across entity types or projects, while still allowing for some custom behavior.